### PR TITLE
Add Zakura and Zebra snapshot resources

### DIFF
--- a/src/content/zcash-z3/resources.mdx
+++ b/src/content/zcash-z3/resources.mdx
@@ -27,17 +27,38 @@ wallet developed entirely in RustLang by [ZODL](https://www.zodl.com)
 
 | [GitHub](https://github.com/zcash/wallet) | [Roadmap](https://zcash.github.io/developers/zcash-zcashd-deprecation-dag) |
 
+## Zakura
+
+Zakura is a Zcash full node written in Rust. It syncs and validates the Zcash
+blockchain, participates in the peer-to-peer network, and provides RPC access
+for applications and infrastructure. It can be installed with Cargo or run as
+a Docker container.
+
+Zakura contains a wrapper for Zcashd wallet CLI. Use this approach if you need
+additional time to migrate to Zebra and Zallet (or Z3).
+
+[GitHub](https://github.com/zakura-core/zakura)
+
+## Community Maintained Snapshots
+
+[Zebra Snapshots by ValarGroup](https://zebra.valargroup.dev/) provides daily,
+checksum-verified Zcash mainnet state snapshots in archive and pruned formats.
+These snapshots help bring a Zebra node close to the chain tip without syncing
+the entire blockchain from scratch.
+
 ## Legacy (Zcashd)
 
 Zcashd is the originary consensus node for Zcash. Forked from Bitcoin-core in 2015,
 Zcashd has gone through six Network Upgrades and has been the main consensus node
-since the Zcash network was deployed in October 28th 2016. It's currently being 
-deprecated and will soon be replaced by Zebra when the Network Upgrade 6.3 (NU6.3) is
-deployed. On July 28th 2026
+since the Zcash network was deployed in October 28th 2016. It's currently being
+deprecated and will soon be replaced by Zebra when Network Upgrade 6.3 (NU6.3) is
+deployed on July 28th, 2026.
+
+ZODL Engineers will be posting updates on this website:
+https://z.cash/support/zcashd-deprecation/
 
 
 | [GitHub](https://github.com/zcash/zcash) | [Roadmap](https://zcash.github.io/developers/zcash-zcashd-deprecation-dag) | [Read The Docs](https://zcash.readthedocs.io/en/latest/)
-
 
 
 ## Zcash Block Explorer


### PR DESCRIPTION
## Summary

- add a Zakura overview and repository link
- add ValarGroup's community-maintained Zebra snapshot service
- update the zcashd deprecation details after rebasing onto current main