### PR TITLE
Add zcashd migration guide and live EOL timeline widget

### DIFF
--- a/src/components/ZcashdEolTimeline.jsx
+++ b/src/components/ZcashdEolTimeline.jsx
@@ -1,0 +1,253 @@
+'use client'
+
+import { Fragment, useEffect, useState } from 'react'
+
+// Milestones from https://zcash.github.io/zcash/user/end-of-life.html
+// Timestamps are UTC midnight of the listed day; day precision is all the
+// source page provides, and two of the dates are themselves estimates.
+const MILESTONES = [
+  {
+    ts: Date.UTC(2026, 6, 2),
+    date: 'July 2nd, 2026',
+    title: 'Ironwood / NU6.3 testnet deployment',
+    detail: 'NU6.3-ready node releases are deployed to testnet.',
+  },
+  {
+    ts: Date.UTC(2026, 6, 4),
+    date: 'July 4th, 2026',
+    title: 'Ironwood / NU6.3 testnet activation',
+    detail: 'NU6.3 activates on testnet at block 4,134,000.',
+  },
+  {
+    ts: Date.UTC(2026, 6, 9),
+    date: 'July 9th, 2026',
+    title: 'Ironwood / NU6.3 mainnet deployment',
+    detail: 'NU6.3-ready node releases are published for mainnet.',
+  },
+  {
+    ts: Date.UTC(2026, 6, 18),
+    date: '~July 18th, 2026',
+    estimated: true,
+    title: 'zcashd End-of-Support halt',
+    detail:
+      'At mainnet block 3,417,100 every remaining zcashd binary ' +
+      'automatically shuts down and refuses to restart.',
+  },
+  {
+    ts: Date.UTC(2026, 6, 28),
+    date: '~July 28th, 2026',
+    estimated: true,
+    title: 'Ironwood / NU6.3 mainnet activation',
+    detail:
+      'NU6.3 activates on mainnet. zcashd does not support NU6.3 — ' +
+      'the network is Zebra-only from here on.',
+  },
+]
+
+const DAY = 86_400_000
+
+function daysUntil(ts, now) {
+  return Math.max(1, Math.ceil((ts - now) / DAY))
+}
+
+function YouAreHere({ now, next }) {
+  return (
+    <li className="eolw-here" aria-current="step">
+      <span className="eolw-dot eolw-dot-here" aria-hidden="true" />
+      <div className="eolw-body">
+        <span className="eolw-here-label">You are here</span>
+        <span className="eolw-here-detail">
+          {next
+            ? `${daysUntil(next.ts, now)} day${daysUntil(next.ts, now) === 1 ? '' : 's'} until ${next.title}${next.estimated ? ' (estimated)' : ''}`
+            : 'zcashd has reached End-of-Life. The network is Zebra-only.'}
+        </span>
+      </div>
+    </li>
+  )
+}
+
+export function ZcashdEolTimeline() {
+  const [now, setNow] = useState(null)
+
+  useEffect(() => {
+    setNow(Date.now())
+    const id = setInterval(() => setNow(Date.now()), 60_000)
+    return () => clearInterval(id)
+  }, [])
+
+  // Index of the first milestone still in the future; -1 → all have passed.
+  const nextIdx = now === null ? null : MILESTONES.findIndex((m) => now < m.ts)
+  const next = nextIdx === null || nextIdx === -1 ? null : MILESTONES[nextIdx]
+
+  return (
+    <div className="eolw" role="group" aria-label="zcashd End-of-Life timeline">
+      <style>{CSS}</style>
+      <div className="eolw-head">
+        <strong>zcashd End-of-Life timeline</strong>
+        {now !== null && (
+          <span className={`eolw-pill ${next ? '' : 'eolw-pill-over'}`}>
+            {next
+              ? `${daysUntil(next.ts, now)}d to next milestone`
+              : 'timeline complete'}
+          </span>
+        )}
+      </div>
+      <ol className="eolw-list">
+        {MILESTONES.map((m, i) => {
+          const passed = now !== null && (nextIdx === -1 || i < nextIdx)
+          const isNext = nextIdx === i
+          return (
+            <Fragment key={m.ts}>
+              {isNext && <YouAreHere now={now} next={next} />}
+              <li
+                className={`eolw-item ${passed ? 'eolw-passed' : ''} ${isNext ? 'eolw-next' : ''}`}
+              >
+                <span className="eolw-dot" aria-hidden="true">
+                  {passed ? '✓' : ''}
+                </span>
+                <div className="eolw-body">
+                  <span className="eolw-date">
+                    {m.date}
+                    {m.estimated && <em> · estimated</em>}
+                  </span>
+                  <span className="eolw-title">{m.title}</span>
+                  <span className="eolw-detail">{m.detail}</span>
+                </div>
+              </li>
+            </Fragment>
+          )
+        })}
+        {now !== null && nextIdx === -1 && <YouAreHere now={now} next={null} />}
+      </ol>
+      <div className="eolw-foot">
+        Source:{' '}
+        <a
+          href="https://zcash.github.io/zcash/user/end-of-life.html"
+          target="_blank"
+          rel="noreferrer"
+        >
+          zcashd End-of-Life documentation
+        </a>
+        . Block-height milestones are estimates and may shift by a few days.
+      </div>
+    </div>
+  )
+}
+
+const CSS = `
+.eolw {
+  border: 1px solid var(--zec-border, #e8e3d6);
+  background: var(--zec-surface, #fff);
+  border-radius: 12px;
+  padding: 1.25rem 1.25rem 1rem;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+}
+.eolw-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+.eolw-pill {
+  border: 1px solid var(--zec-amber-strong, #b67d08);
+  color: var(--zec-amber-strong, #b67d08);
+  border-radius: 999px;
+  padding: 0.1rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.eolw-pill-over {
+  border-color: var(--zec-teal, #0e9488);
+  color: var(--zec-teal, #0e9488);
+}
+.eolw-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.eolw-item, .eolw-here {
+  position: relative;
+  display: flex;
+  gap: 0.85rem;
+  padding: 0 0 1.1rem 0;
+}
+.eolw-list > *:not(:last-child)::before {
+  content: '';
+  position: absolute;
+  left: 0.65rem;
+  top: 1.4rem;
+  bottom: -0.1rem;
+  width: 2px;
+  background: var(--zec-border, #e8e3d6);
+}
+.eolw-passed:not(:last-child)::before {
+  background: var(--zec-amber, #f0b429);
+}
+.eolw-dot {
+  flex: none;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 50%;
+  border: 2px solid var(--zec-border, #e8e3d6);
+  background: var(--zec-surface, #fff);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  line-height: 1;
+  color: #fff;
+  margin-top: 0.1rem;
+  z-index: 1;
+}
+.eolw-passed .eolw-dot {
+  background: var(--zec-amber, #f0b429);
+  border-color: var(--zec-amber, #f0b429);
+  color: #3a2c00;
+}
+.eolw-next .eolw-dot {
+  border-color: var(--zec-amber-strong, #b67d08);
+}
+.eolw-dot-here {
+  background: var(--zec-coral, #dc5236);
+  border-color: var(--zec-coral, #dc5236);
+  animation: eolw-pulse 2s ease-in-out infinite;
+}
+@keyframes eolw-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(220, 82, 54, 0.45); }
+  50% { box-shadow: 0 0 0 7px rgba(220, 82, 54, 0); }
+}
+.eolw-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+.eolw-date {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--zec-muted, #6e685a);
+}
+.eolw-date em { text-transform: none; font-style: italic; }
+.eolw-title { font-weight: 700; }
+.eolw-next .eolw-title { color: var(--zec-amber-strong, #b67d08); }
+.eolw-detail, .eolw-here-detail { color: var(--zec-muted, #6e685a); }
+.eolw-here-label {
+  font-weight: 800;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--zec-coral, #dc5236);
+}
+.eolw-foot {
+  border-top: 1px solid var(--zec-border, #e8e3d6);
+  padding-top: 0.6rem;
+  font-size: 0.75rem;
+  color: var(--zec-muted, #6e685a);
+}
+.eolw-foot a { color: var(--zec-amber-strong, #b67d08); }
+`

--- a/src/content/zcash-z3/index.mdx
+++ b/src/content/zcash-z3/index.mdx
@@ -1,6 +1,8 @@
+import { ZcashdEolTimeline } from '../../components/ZcashdEolTimeline'
+
 # Z3: A new Zcash technology Stack 
-Zcash was created from a bitcoin-core fork from 2015. Zcashd has been the 
-main consensus node over 9 years. A complex machinery that combines legacy 
+Zcash was created from a bitcoin-core fork in 2015. Zcashd has been the 
+main consensus node for over 9 years. A complex machinery that combines legacy 
 C++ code from Satoshi's Era, cutting edge Zero Knowledge Proofs, RustLang
 code, a full-node wallet, mining and blockchain indexing RPCs. 
 
@@ -11,9 +13,9 @@ would have to be replaced because the effort of adding new features was huge and
 deemed an inefficient allocation of the development resources of the Zcash 
 development budget. ZODL core developers made the decision of starting to 
 deprecate Zcashd in favor of a new technology stack composed of Zebra, a RustLang
-modern consensus node  developed by the Zcash Foundation engineering team and, 
-Zaino an indexer called developed by ZingoLabs. ZOLD would be in charge of 
-developing the full-node wallet that would connect to Zaino and Zebra called 
+modern consensus node developed by the Zcash Foundation engineering team, and 
+Zaino, an indexer developed by ZingoLabs. ZODL would be in charge of 
+developing the full-node wallet that would connect to Zaino and Zebra, called 
 Zallet.
 
 Zcashd deprecation is a cross-team ecosystem-wide effort which is targeted for
@@ -21,22 +23,69 @@ end of July of 2026.
 
 ## Zcashd Deprecation is now Z^3
 
-Zcashd Deprecation was deemed a negative narrative. In order to focus in the 
-positive aspects of the outcomes of this proces, it was then renamed to 
+Zcashd Deprecation was deemed a negative narrative. In order to focus on the 
+positive aspects of the outcomes of this process, it was then renamed to 
 Z^3 (Zebra x Zaino x Zallet). If you'd like to contribute to Z3, check out the 
 contributing section.
 
 "Zee Three" or "Zee to the Three" is an original idea from Zancas (ZingoLabs).
 
-# Use cases
+# Migration Guide: moving off Zcashd
+
+> ## ⚠️ Zcashd is shutting down
+>
+> `zcashd` is **deprecated**, will **not** support NU6.3, and its
+> **End-of-Support halt** is estimated for **July 18th 2026** at block height
+> 3417100, after which every `zcashd` node automatically shuts down.
+> See the [Zcashd End-of-Life page](/zcash-z3/zcashd_cycle) for the full timeline.
+
+<ZcashdEolTimeline />
+
+This guide condenses the next steps for everyone still running Zcashd — node
+operators, miners, exchanges, and services that depend on the Zcashd wallet CLI.
+Find your situation below and follow the corresponding path.
+
+> **Note:** This page is a community resource. It is not associated with, or
+> endorsed by, the Zcash Foundation, ZODL, ZingoLabs, Valar Group, or any other
+> Zcash organization.
+
+## Which path should I take?
+
+| Your current situation | Migrate to | When |
+| -- | -- | -- |
+| Full node, **no** indexing or wallet needs | [Zebra](https://github.com/ZcashFoundation/zebra) | **Now** |
+| Service that needs **indexed** blockchain data (explorers, APIs) | [Zebra](https://github.com/ZcashFoundation/zebra) + [Zaino](https://github.com/zingolabs/zaino/) | **Now** |
+| You use the **Zcashd wallet CLI / wallet RPCs** | Zebra + [Zallet](https://github.com/zcash/zallet) (with Zaino or Zebra as backend) | **Now** — start testing immediately |
+| You **can't complete** the wallet migration before EOL and need the existing Zcashd APIs | [Zakura](https://github.com/zakura-core/zakura) + [zcashd-compat mode](https://github.com/zakura-core/zakura/blob/main/book/src/user/zcashd-compat.md) | **Temporary bridge only** — plan your Z3 migration in parallel |
+
+Whatever path you take, remember: **the zcashd-compat bridge is temporary. All
+users will eventually have to migrate to Zebra and Zallet** (or Zebra / Zebra +
+Zaino if they don't need a wallet).
+
+## Before you migrate: back up everything
+
+- **Always back up your current data.** Before touching anything, make copies of
+  your Zcashd data directory — especially your `wallet.dat` — and store them
+  somewhere safe. A failed migration with a good backup is an inconvenience;
+  without one, it can mean losing funds.
+- **Always back up your Zebra chain state before running a migration.** Copy the
+  Zebra state directory before pointing new components (Zaino, Zallet) at it or
+  upgrading versions, so you can roll back without a full resync.
+- **Community-maintained snapshots for Zebra are available.** If you need to
+  (re)build a Zebra node quickly, daily checksum-verified mainnet snapshots can
+  bring it close to the chain tip without syncing from scratch. See the
+  [Community Maintained Snapshots](/zcash-z3/resources#community-maintained-snapshots)
+  entry in the Resources section.
 
 ## If you run a full node (no wallet)
 
-Zebra is Zcash's Consensus node completely implemented in RustLang by [Zcash Foundation](https://zfnd.org/)
+Zebra is Zcash's consensus node, completely implemented in RustLang by the [Zcash Foundation](https://zfnd.org/).
 
-Zebra validates consensus and has limited indexing capabilities by design. 
-Find out more about Zebra on [Github](https://github.com/ZcashFoundation/zebra) 
-or reading [The Zebra Book](https://zebra.zfnd.org/)
+Zebra validates consensus and has limited indexing capabilities by design.
+**You can move to Zebra today** — no other components required.
+
+Find out more about Zebra on [GitHub](https://github.com/ZcashFoundation/zebra) 
+or by reading [The Zebra Book](https://zebra.zfnd.org/).
 
 ## If you run a service that needs Zcash indexed data
 
@@ -44,24 +93,79 @@ Zcashd RPCs which served indexed data of the Zcash blockchain are now replaced b
 [Zaino](https://github.com/zingolabs/zaino/). Zaino connects to a Zebra node to
 create indexed views of the finalized and non-finalized states of the Zebra node. 
 
-If you run a block explorer and depended on those RPCs you should deploy Zaino and
-Zebra and use Zaino as your indexer. 
+If you run a block explorer or any service that depended on those RPCs, you
+should deploy Zebra and Zaino and use Zaino as your indexer. **This stack is
+ready today.**
 
-## If you ran a Zcashd wallet
+## If you rely on the Zcashd wallet CLI
 
 The Zcashd wallet is deprecated and will cease to run on July 18th 2026. 
 
-You should migrate to Zallet, the replacement for the Zcashd full-node
-wallet developed entirely in RustLang by [ZODL](https://www.zodl.com)
+You should migrate to [Zallet](https://github.com/zcash/zallet), the replacement
+for the Zcashd full-node wallet, developed entirely in RustLang by
+[ZODL](https://www.zodl.com). Zallet runs against a Zebra node and lets you opt
+for one of two backends:
 
-Find out more about Zallet on its [GitHub](https://github.com/zcash/zallet) repository
+- **Zaino** — the recommended setup and the full Z3 stack (Zebra x Zaino x Zallet).
+- **Zebra (zebrad) directly** — a standalone setup without the indexer.
 
-Although you can run Zallet standalone backed by a Zebra node we encourage you to 
-use the Z3 stack (See section below )
+Start by migrating your `wallet.dat` and testing your integration against
+Zallet **as soon as possible**. Find out more in the
+[Zallet book](https://zcash.github.io/zallet/) and its
+[GitHub](https://github.com/zcash/zallet) repository.
+
+## If you are a miner
+
+Migrate your node to Zebra and request block templates from it. If you operate
+under Zakura's zcashd-compat mode (below), note that the **mining RPCs are
+removed from the sidecar zcashd**: block templates must be requested from
+Zakura's RPC interface, not from zcashd's.
+
+## If you need more time: Zakura + zcashd-compat mode (temporary)
+
+[Zakura](https://github.com/zakura-core/zakura) is a full node developed by
+Valar Group. Its
+[zcashd-compat mode](https://github.com/zakura-core/zakura/blob/main/book/src/user/zcashd-compat.md)
+is aimed at operators — typically exchanges and custodial services — that cannot
+complete their migration to Zallet before Zcashd's End-of-Life and need to keep
+their existing Zcashd integrations running in the meantime.
+
+How it works:
+
+- **Zakura faces the network.** Zakura is the consensus-validating node connected
+  to the Zcash peer-to-peer network.
+- **Zcashd becomes a sidecar.** A patched zcashd fork runs alongside it, making a
+  single outbound connection to Zakura and accepting **no inbound peer-to-peer
+  connections**. Your zcashd node is no longer exposed to the P2P network.
+- **Your existing APIs keep working.** The zcashd wallet RPCs (transparent and
+  Sapling), local block files, chainstate, and ZMQ notifications stay unchanged.
+- **Extended End-of-Life.** The compat-mode zcashd fork keeps running **past
+  NU6.3 activation**, which is stock Zcashd's End-of-Life as indicated in
+  [Zcashd's documentation](https://zcash.github.io/zcash/user/end-of-life.html).
+
+### Limitations you must plan around
+
+- **Ironwood pool: permanently unsupported** in the sidecar zcashd.
+- **Orchard: rejected after NU6.3 activation.** Orchard operations work before
+  activation and return errors afterwards.
+- **Transparent and Sapling operations are unaffected.**
+- Mining RPCs are removed from the sidecar zcashd (use Zakura's RPC instead).
+
+### This is a temporary solution
+
+The zcashd-compat mode buys you time; it is **not** a destination. **All users
+will have to migrate to Zebra and Zallet** for wallet CLI functionality — or to
+Zebra (optionally with Zaino) if they don't require a wallet. Use the extra
+runway to execute your Z3 migration, not to postpone it.
+
+## Testing your migration on testnet
+
+A Zcash testnet faucet with **Ironwood support** is available at
+[fauzec.com](https://fauzec.com/). Use it to fund test wallets and validate your
+Zallet integration — including Orchard and Ironwood flows — before moving to
+mainnet.
 
 ## Zcash Z3 containerized stack 
 
-Zcash Foundation maintains the [Z3 stack](https://github.com/ZcashFoundation/z3). Which 
+Zcash Foundation maintains the [Z3 stack](https://github.com/ZcashFoundation/z3), which 
 comprises Zebra, Zaino and Zallet.
-
-

--- a/src/content/zcash-z3/zcashd_cycle.mdx
+++ b/src/content/zcash-z3/zcashd_cycle.mdx
@@ -1,3 +1,5 @@
+import { ZcashdEolTimeline } from '../../components/ZcashdEolTimeline'
+
 # Zcashd End-of-Life
 
 > ## ⚠️ `zcashd` is reaching its End of Life
@@ -10,3 +12,5 @@
 > automatically shuts down.
 
 See [Zcash'd book chapter](https://zcash.github.io/zcash/user/end-of-life.html) on Zcashd EOL.
+
+<ZcashdEolTimeline />


### PR DESCRIPTION
## Summary

Expands the Z3 page into a comprehensive, shareable migration guide for everyone still on zcashd (node operators, miners, exchanges, wallet-CLI users), and adds a live EOL timeline widget.

### Migration guide (`src/content/zcash-z3/index.mdx`)
- EOL warning callout with a "which path should I take?" table mapping each situation to its destination:
  - Full node, no indexing → **Zebra** (now)
  - Indexed data services → **Zebra + Zaino** (now)
  - Zcashd wallet CLI → **Zallet** (backend: Zaino or zebrad)
  - Need more time → **Zakura + zcashd-compat mode** (temporary bridge only)
- Zakura zcashd-compat section grounded in the [official docs](https://github.com/zakura-core/zakura/blob/main/book/src/user/zcashd-compat.md): sidecar architecture (no inbound P2P to zcashd), extended EOL past NU6.3 activation, and its limitations (Ironwood unsupported, Orchard rejected post-NU6.3, transparent/Sapling unaffected). Explicitly framed as temporary — all users must ultimately migrate to Z3.
- Dedicated miners section (block templates via Zebra, or Zakura's RPC under compat mode — mining RPCs are removed from the sidecar zcashd).
- "Before you migrate" backup guidance (zcashd data / `wallet.dat`, Zebra chain state) plus a pointer to the community-maintained Zebra snapshots in Resources.
- Testnet section pointing to the Ironwood-supporting faucet at [fauzec.com](https://fauzec.com/).
- Community-resource disclaimer (not associated with ZF, ZODL, ZingoLabs, Valar Group, or any other org).
- Fixes a few typos in the intro (ZOLD → ZODL, etc.).

### Live EOL timeline widget (`src/components/ZcashdEolTimeline.jsx`)
- Client component rendering the five milestones from the [zcashd End-of-Life documentation](https://zcash.github.io/zcash/user/end-of-life.html), with a pulsing "You are here" marker computed from the visitor's clock, a countdown to the next milestone, and passed-milestone progress styling.
- Styled with the site's `--zec-*` theme variables (dark mode supported); hydration-safe for the static export.
- Embedded on both `/zcash-z3` and `/zcash-z3/zcashd_cycle`.

## Test plan
- [x] `pnpm build` passes (static export)
- [x] Verified widget markup present in exported HTML for both pages
- [ ] Visual check of the timeline widget in light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)